### PR TITLE
[#15] muiのコンポーネントに独自cssを当てる

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,9 @@ import SignIn from "components/pages/SignIn"
 
 import { getCurrentUser } from "lib/api/auth"
 import { User } from "interfaces/index"
+import { ThemeProvider, createTheme } from '@mui/material/styles'
+
+
 
 // グローバルで扱う変数・関数
 export const AuthContext = createContext({} as {
@@ -45,6 +48,17 @@ const App: React.FC = () => {
     setLoading(false)
   }
 
+  const theme = createTheme({
+    palette: {
+      mode: 'light',
+       primary: {
+         main: '#9565e6',
+         light: '#9565e6',
+         dark: '#9565e6'
+        }
+      }  
+  })
+
   useEffect(() => {
     handleGetCurrentUser()
   }, [setCurrentUser])
@@ -52,13 +66,15 @@ const App: React.FC = () => {
   return (
     <Router>
       <AuthContext.Provider value={{ loading, setLoading, isSignedIn, setIsSignedIn, currentUser, setCurrentUser}}>
-        <CommonLayout>
-          <Routes>
-            <Route path="/signup" element={<SignUp />} />
-            <Route path="/signin" element={<SignIn />} />
-            <Route path="/" element={<Home />} />
-          </Routes>
-        </CommonLayout>
+        <ThemeProvider theme={theme}>
+          <CommonLayout>
+            <Routes>
+              <Route path="/signup" element={<SignUp />} />
+              <Route path="/signin" element={<SignIn />} />
+              <Route path="/" element={<Home />} />
+            </Routes>
+          </CommonLayout>
+        </ThemeProvider>
       </AuthContext.Provider>
     </Router>
   )

--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -2,8 +2,6 @@ import React, { useContext } from "react"
 import { useNavigate, Link } from "react-router-dom"
 import Cookies from "js-cookie"
 
-import { Theme } from '@mui/material/styles'
-
 import AppBar from "@mui/material/AppBar"
 import Toolbar from "@mui/material/Toolbar"
 import Typography from "@mui/material/Typography"

--- a/frontend/src/components/pages/SignIn.tsx
+++ b/frontend/src/components/pages/SignIn.tsx
@@ -5,11 +5,12 @@ import Cookies from "js-cookie"
 import { Theme } from '@mui/material/styles'
 import { Typography } from "@mui/material"
 import TextField from "@mui/material/TextField"
-import Card from "@mui/material/Card"
 import CardContent from "@mui/material/CardContent"
 import CardHeader from "@mui/material/CardHeader"
 import Button from "@mui/material/Button"
 import Box from "@mui/material/Box"
+
+import FormCard from "../utils/FormCard"
 
 import { AuthContext } from "App"
 import AlertMessage from "components/utils/AlertMessage"
@@ -62,7 +63,7 @@ const SignIn: React.FC = () => {
   return (
     <>
       <form noValidate autoComplete="off">
-        <Card>
+        <FormCard>
           <CardHeader title="Sign In" />
           <CardContent>
             <TextField
@@ -106,7 +107,7 @@ const SignIn: React.FC = () => {
               </Typography>
             </Box>
           </CardContent>
-        </Card>
+        </FormCard>
       </form>
       <AlertMessage // エラーが発生した場合はアラートを表示
         open={alertMessageOpen}

--- a/frontend/src/components/pages/SignUp.tsx
+++ b/frontend/src/components/pages/SignUp.tsx
@@ -4,10 +4,11 @@ import Cookies from "js-cookie"
 
 import { Theme } from '@mui/material/styles'
 import TextField from "@mui/material/TextField"
-import Card from "@mui/material/Card"
 import CardContent from "@mui/material/CardContent"
 import CardHeader from "@mui/material/CardHeader"
 import Button from "@mui/material/Button"
+
+import FormCard from "../utils/FormCard"
 
 import { AuthContext } from "App"
 import AlertMessage from "components/utils/AlertMessage"
@@ -66,7 +67,7 @@ const SignUp: React.FC = () => {
   return (
     <>
       <form noValidate autoComplete="off">
-        <Card>
+        <FormCard>
           <CardHeader title="Sign Up" />
           <CardContent>
             <TextField
@@ -121,7 +122,7 @@ const SignUp: React.FC = () => {
               Submit
             </Button>
           </CardContent>
-        </Card>
+        </FormCard>
       </form>
       <AlertMessage // エラーが発生した場合はアラートを表示
         open={alertMessageOpen}

--- a/frontend/src/components/utils/FormCard.tsx
+++ b/frontend/src/components/utils/FormCard.tsx
@@ -1,0 +1,8 @@
+import Card from "@mui/material/Card"
+import { styled } from "@mui/material/styles"
+
+const FormCard = styled(Card)({
+  margin: 30
+})
+
+export default FormCard;


### PR DESCRIPTION
# issue
#15 

# 概要
掲題の通り

# 使ったライブラリ
Theme, styled from @mui/material/styles

# やったこと
- primary カラーを 薄紫に変更
- Card に margin を設定

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - アプリにMaterial-UIを使用したテーマ機能を追加。これにより、ライトモードの特定のプライマリカラーが設定されます。
  
- **改善**
  - `SignIn`および`SignUp`ページのフォームカードがカスタム`FormCard`コンポーネントに置き換えられました。これによりフォームのレイアウトやスタイリングが改善されます。

- **削除**
  - `Header`コンポーネントから不要な`Theme`インポートを削除しました。

- **追加**
  - 新しい`FormCard`コンポーネントを追加し、標準のMaterial-UI `Card`コンポーネントに30のマージンを適用しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->